### PR TITLE
Update: Simplify tank-related prop handling

### DIFF
--- a/src/components/Results/FuelTank.tsx
+++ b/src/components/Results/FuelTank.tsx
@@ -3,13 +3,12 @@ import useModules from '@/hooks/useModules'
 import Tank from '@/components/Results/Tank'
 type Props = {
   required: number
-  numberOfTanks: number
 }
 
-function FuelTank({required, numberOfTanks}: Props) {
-
+function FuelTank({required}: Props) {
+  const {fuelTanks} = useModules()
   return <>
-    <Tank required={required} limitAmountPerTank={900} numberOfTanks={numberOfTanks} image='img_fuel_tank'></Tank>
+    <Tank required={required} limitAmountPerTank={900} numberOfTanks={fuelTanks.length} image='img_fuel_tank'></Tank>
   </>
 }
 

--- a/src/components/Results/OxidizerTank.tsx
+++ b/src/components/Results/OxidizerTank.tsx
@@ -4,11 +4,10 @@ import {useEffect} from 'react'
 import Tank from '@/components/Results/Tank'
 type Props = {
   required: number
-  numberOfTanks: number
 }
 
-function OxidizerTank({required, numberOfTanks}: Props) {
-  const {oxidizerType, setOxidizerType, changeOxidizerTankByType} = useModules()
+function OxidizerTank({required}: Props) {
+  const {oxidizerTanks, oxidizerType, setOxidizerType, changeOxidizerTankByType} = useModules()
 
   useEffect(() => {
     changeOxidizerTankByType()
@@ -17,7 +16,7 @@ function OxidizerTank({required, numberOfTanks}: Props) {
 
 
   return <>
-    <Tank required={required} limitAmountPerTank={2700} numberOfTanks={numberOfTanks} image={oxidizerType === 'solid' ? 'img_solid_oxidizer_tank' : 'img_liquid_oxidizer_tank'} >
+    <Tank required={required} limitAmountPerTank={2700} numberOfTanks={oxidizerTanks.length} image={oxidizerType === 'solid' ? 'img_solid_oxidizer_tank' : 'img_liquid_oxidizer_tank'} >
       <div className="OxidizerTank">
         <ul className="OxidizerTank_selector">
           <li className={`OxidizerTank_type -solid ${oxidizerType === 'solid' ? '-selected' : ''}`} onClick={() => setOxidizerType('solid')}>

--- a/src/components/Results/Results.tsx
+++ b/src/components/Results/Results.tsx
@@ -15,12 +15,10 @@ import FuelAmount from '@/components/Results/FuelAmount'
 type Props = {}
 
 function Results({}: Props) {
-  const {head, engine, thruster, modules, oxidizerType} = useModules()
+  const {head, engine, thruster, modules, oxidizerType, setNumberOfFuelTanks, setNumberOfOxidizerTanks} = useModules()
   const {amount,  amountCalculate, setIsCalculating} = useAmount()
   const {distance} = useContext<tDistanceContext>(DistanceContext)
   const [isShowSelectedModuleArea, setIsShowSelectedModuleArea] = useState(false)
-  const [numberOfFuelTanks, setNumberOfFuelTanks] = useState(0)
-  const [numberOfOxidizerTanks, setNumberOfOxidizerTanks] = useState(0)
 
   // 依存値を1つのオブジェクトにまとめてメモ化
   const params = useMemo(() => ({
@@ -70,13 +68,13 @@ function Results({}: Props) {
             <div className="Results_cell -fuel">
               <div className="Results_title">Fuel Tanks</div>
               <div className="Results_content">
-                <FuelTank required={amount} numberOfTanks={numberOfFuelTanks} />
+                <FuelTank required={amount} />
               </div>
             </div>
             <div className="Results_cell -oxidizer">
               <div className="Results_title">Oxidizer Tanks</div>
               <div className="Results_content">
-                <OxidizerTank required={amount} numberOfTanks={numberOfOxidizerTanks} />
+                <OxidizerTank required={amount} />
               </div>
             </div>
           </>}

--- a/src/hooks/useModules.tsx
+++ b/src/hooks/useModules.tsx
@@ -55,7 +55,7 @@ function useModules() {
    * Set the number of fuel tanks to the specified number(num)
    * @param num
    */
-  const setNumberOfFuelTank = (num:number) => {
+  const setNumberOfFuelTanks = (num:number) => {
     if(modules.engine.name === "Steam Engine") return
     const tanks = [] as tItem[]
     for(let i = 0; i < num; i++) {
@@ -69,7 +69,7 @@ function useModules() {
    * Set the number of oxidizer tanks to the specified number(num)
    * @param num
    */
-  const setNumberOfOxidizerTank = (num:number) => {
+  const setNumberOfOxidizerTanks = (num:number) => {
     if(modules.engine.name === "Steam Engine") return
     const tanks = [] as tItem[]
     for(let i = 0; i < num; i++) {
@@ -180,8 +180,8 @@ function useModules() {
     removeModule,
     addOxidizerTank,
     changeOxidizerTankByType,
-    setNumberOfFuelTank,
-    setNumberOfOxidizerTank,
+    setNumberOfFuelTanks,
+    setNumberOfOxidizerTanks,
     reset,
     includes,
     setOxidizerType: modules.methods.setOxidizerType,


### PR DESCRIPTION
`FuelTank`および`OxidizerTank`コンポーネントから`numberOfTanks`プロップを削除し、必要なタンク数を内部で計算するロジックに置き換えました。これにより、コンポーネント間のデータ依存性が低減し、保守性が向上しました。また、`useModules`内の関連メソッド名を修正し、一貫性を持たせました。